### PR TITLE
Fix "UnicodeWarning: Unicode equal comparison failed" warnings for unicode filenames on Python 2

### DIFF
--- a/piexif/_insert.py
+++ b/piexif/_insert.py
@@ -1,5 +1,6 @@
 import io
 import struct
+import sys
 
 from ._common import *
 from ._exceptions import InvalidImageDataError
@@ -18,10 +19,13 @@ def insert(exif, image, new_file=None):
         raise ValueError("Given data is not exif data")
 
     output_file = False
-    if image[0:2] == b"\xff\xd8":
+    # Prevents "UnicodeWarning: Unicode equal comparison failed" warnings on Python 2
+    maybe_image = sys.version_info >= (3,0,0) or isinstance(image, str)
+
+    if maybe_image and image[0:2] == b"\xff\xd8":
         image_data = image
         file_type = "jpeg"
-    elif image[0:4] == b"RIFF" and image[8:12] == b"WEBP":
+    elif maybe_image and image[0:4] == b"RIFF" and image[8:12] == b"WEBP":
         image_data = image
         file_type = "webp"
     else:


### PR DESCRIPTION
Fixes #64

This change prevents the code from checking image bytes on unicode filenames. (I'm assuming that no-one will be passing in a unicode string for image data.)

It was easier to keep the same `if`, `elif`, `else` ... flow, so I added a `maybe_image` condition before each string comparison.

Just fixes some annoying warnings in my pytest output for Python 2.7.