### PR TITLE
Discard other types of segments that are not Exif (like XMP)

### DIFF
--- a/piexif/_common.py
+++ b/piexif/_common.py
@@ -43,6 +43,8 @@ def read_exif_from_file(filename):
 
         if head[:2] == b"\xff\xe1":
             segment_data = f.read(length - 2)
+            if segment_data[0:4] != b'Exif':
+                break
             exif = head + segment_data
             break
         elif head[0:1] == b"\xff":


### PR DESCRIPTION
It seems that APP1 segments can contain other types of content, like XMP (see https://wwwimages2.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart3.pdf - page 13)