### PR TITLE
Fix  "local variable 'file_type' referenced before assignment", and improve performance in common exif removal case

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.1.4
+-----
+
+- Fixed "local variable 'file_type' referenced before assignment" if image type wasn't known.
+- No longer write image back to source image file if nothing has changed for better performance.
+
 1.1.3
 -----
 

--- a/piexif/__init__.py
+++ b/piexif/__init__.py
@@ -8,4 +8,4 @@ from ._exceptions import *
 
 
 
-VERSION = '1.1.3'
+VERSION = '1.1.4'

--- a/piexif/_remove.py
+++ b/piexif/_remove.py
@@ -26,31 +26,35 @@ def remove(src, new_file=None):
             file_type = "jpeg"
         elif src_data[0:4] == b"RIFF" and src_data[8:12] == b"WEBP":
             file_type = "webp"
-
-    if file_type == "jpeg":
-        segments = split_into_segments(src_data)
-        exif = get_exif_seg(segments)
-        if exif:
-            new_data = src_data.replace(exif, b"")
         else:
-            new_data = src_data
-    elif file_type == "webp":
-        try:
-            new_data = _webp.remove(src_data)
-        except ValueError:
-            new_data = src_data
-        except e:
-            print(e.args)
-            raise ValueError("Error occurred.")
+            file_type = None
 
-    if isinstance(new_file, io.BytesIO):
-        new_file.write(new_data)
-        new_file.seek(0)
-    elif new_file:
-        with open(new_file, "wb+") as f:
-            f.write(new_data)
-    elif output_is_file:
-        with open(src, "wb+") as f:
-            f.write(new_data)
-    else:
-        raise ValueError("Give a second argument to 'remove' to output file")
+    if file_type is not None:
+        if file_type == "jpeg":
+            segments = split_into_segments(src_data)
+            exif = get_exif_seg(segments)
+            if exif:
+                new_data = src_data.replace(exif, b"")
+            else:
+                new_data = src_data
+        elif file_type == "webp":
+            try:
+                new_data = _webp.remove(src_data)
+            except ValueError:
+                new_data = src_data
+            except e:
+                print(e.args)
+                raise ValueError("Error occurred.")
+
+        if isinstance(new_file, io.BytesIO):
+            new_file.write(new_data)
+            new_file.seek(0)
+        elif new_file:
+            with open(new_file, "wb+") as f:
+                f.write(new_data)
+        elif output_is_file:
+            if new_data is not src_data:
+                with open(src, "wb+") as f:
+                    f.write(new_data)
+        else:
+            raise ValueError("Give a second argument to 'remove' to output file")

--- a/tests/images/not_an_image.txt
+++ b/tests/images/not_an_image.txt
@@ -1,0 +1,1 @@
+This tests _remove() handling of files that are not jpgs or webp

--- a/tests/s_test.py
+++ b/tests/s_test.py
@@ -1010,6 +1010,14 @@ class WebpTests(unittest.TestCase):
             piexif.remove(IMAGE_DIR + filename, OUT_DIR + "rr_" + filename)
             Image.open(OUT_DIR + "rr_" + filename)
 
+    def test_remove_unknown_image_type(self):
+        """Does remove ignore unknown image types?"""
+        IMAGE_DIR = "tests/images/"
+        OUT_DIR = "tests/images/out/"
+        filename = "not_an_image.txt"
+        piexif.remove(IMAGE_DIR + filename, OUT_DIR + "rr_" + filename)
+        self.assertFalse(os.path.isfile(OUT_DIR + "rr_" + filename))
+
     def test_insert(self):
         """Can PIL open WebP that is inserted exif?"""
         IMAGE_DIR = "tests/images/"


### PR DESCRIPTION
- Fixed "local variable 'file_type' referenced before assignment" if image type wasn't known.
- No longer write image back to source image file if nothing has changed for better performance. The motivation here is that I've got 10000+ of images that I need to remove exif data from. Many of the images have already had exif removed previously. Thus writing unchanged data back to the source file was making batch processing take a lot longer than it needed to.
