### PR TITLE
ascii values without \x00 ending

### DIFF
--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -153,7 +153,8 @@ class _ExifReader(object):
         elif t == TYPES.Ascii: # ASCII
             if length > 4:
                 pointer = struct.unpack(self.endian_mark + "L", value)[0]
-                data = self.tiftag[pointer: pointer+length - 1]
+                data = self.tiftag[pointer: pointer+length]
+                data = data.split(b'\x00', 1)[0]
             else:
                 data = value[0: length - 1]
         elif t == TYPES.Short: # SHORT


### PR DESCRIPTION
in some images there are ascii values  without terminating null character ( \x00 ).
this is a fix for that case.
It reduces all characters after a null character in an ascii text

the Github- project exifread solves this problem the same way. Have a look at 
https://github.com/ianare/exif-py/blob/develop/exifread/classes.py in method  _process_field2 on line 193.

