### PR TITLE
Better struct module usage

### DIFF
--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -164,15 +164,11 @@ class _ExifReader(object):
                 data = unpack_from(self.endian_mark + "L" * length, value)
         elif t == TYPES.Rational: # RATIONAL
             pointer = unpack_from(self.endian_mark + "L", value)[0]
-            if length > 1:
-                data = tuple(
-                    unpack_from(self.endian_mark + "LL",
-                                self.tiftag, pointer + x * 8)
-                    for x in range(length)
-                )
-            else:
-                data = unpack_from(self.endian_mark + "LL",
-                                   self.tiftag, pointer)
+            data = tuple(
+                unpack_from(self.endian_mark + "LL",
+                            self.tiftag, pointer + x * 8)
+                for x in range(length)
+            )
         elif t == TYPES.SByte: # SIGNED BYTES
             if length > 4:
                 pointer = unpack_from(self.endian_mark + "L", value)[0]
@@ -201,15 +197,11 @@ class _ExifReader(object):
                 data = unpack_from(self.endian_mark + "l" * length, value)
         elif t == TYPES.SRational: # SRATIONAL
             pointer = unpack_from(self.endian_mark + "L", value)[0]
-            if length > 1:
-                data = tuple(
-                  unpack_from(self.endian_mark + "ll",
-                              self.tiftag, pointer + x * 8)
-                  for x in range(length)
-                )
-            else:
-                data = unpack_from(self.endian_mark + "ll",
-                                   self.tiftag, pointer)
+            data = tuple(
+              unpack_from(self.endian_mark + "ll",
+                          self.tiftag, pointer + x * 8)
+              for x in range(length)
+            )
         elif t == TYPES.Float: # FLOAT
             if length > 1:
                 pointer = unpack_from(self.endian_mark + "L", value)[0]

--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -112,20 +112,18 @@ class _ExifReader(object):
             t = "Image"
         else:
             t = ifd_name
-        p_and_value = []
         for x in range(tag_count):
             pointer = offset + 12 * x
             tag, value_type, value_num = unpack_from(
                 self.endian_mark + "HHL", self.tiftag, pointer)
             value = self.tiftag[pointer+8: pointer+12]
-            p_and_value.append((pointer, value_type, value_num, value))
             v_set = (value_type, value_num, value, tag)
             if tag in TAGS[t]:
                 ifd_dict[tag] = self.convert_value(v_set)
             elif read_unknown:
                 ifd_dict[tag] = (v_set[0], v_set[1], v_set[2], self.tiftag)
-            #else:
-            #    pass
+            else:
+                pass
 
         if ifd_name == "0th":
             pointer = offset + 12 * tag_count


### PR DESCRIPTION
This improves usage of standard `struct` module. `unpack_from` function doesn't require extra copying as well as doesn't require data length match.

Also there was a several places where sequence of `unpack` calls can be replaced with single call.

```diff
-            tag = struct.unpack(self.endian_mark + "H",
-                       self.tiftag[pointer: pointer+2])[0]
-            value_type = struct.unpack(self.endian_mark + "H",
-                         self.tiftag[pointer + 2: pointer + 4])[0]
-            value_num = struct.unpack(self.endian_mark + "L",
-                                      self.tiftag[pointer + 4: pointer + 8]
-                                      )[0]
+            tag, value_type, value_num = unpack_from(
+                self.endian_mark + "HHL", self.tiftag, pointer)
```