### PR TITLE
fixes error when reading GPSLatitudeRef and GPSLongitudeRef

### DIFF
--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -154,6 +154,8 @@ class _ExifReader(object):
             if length > 4:
                 pointer = struct.unpack(self.endian_mark + "L", value)[0]
                 data = self.tiftag[pointer: pointer+length - 1]
+            elif length == 1:
+                data = value[0:length]
             else:
                 data = value[0: length - 1]
         elif t == TYPES.Short: # SHORT


### PR DESCRIPTION
This fixes a parsing error when loading exif data. The fix retains the GPSLatitudeRef and GPSLongitudeRef data. This is needed for decimal degree calculation. It is curretly lost. 
Before:
![image](https://user-images.githubusercontent.com/21144129/160104994-9fe0712b-f894-43f9-95ae-a8f3e51bd0e8.png)
After:

![image](https://user-images.githubusercontent.com/21144129/160105651-502d2cc2-69cf-42d8-8d3e-5ea4158106a7.png)
![image](https://user-images.githubusercontent.com/21144129/160105740-cd7ebdbe-b26f-4d48-a368-904778bf57b9.png)
